### PR TITLE
Compilation fix for swift projects

### DIFF
--- a/Framework/EllipticLicense.h
+++ b/Framework/EllipticLicense.h
@@ -17,19 +17,12 @@
 //  limitations under the License.
 
 #import <Cocoa/Cocoa.h>
-#include <openssl/sha.h>
-#include <openssl/ec.h>
-#include <openssl/ecdsa.h>
-#include <openssl/obj_mac.h>
-#include <openssl/ossl_typ.h>
 
 extern NSString *ELCurveNameSecp112r1;
 extern NSString *ELCurveNameSecp128r1;
 extern NSString *ELCurveNameSecp160r1;
 
 @interface EllipticLicense : NSObject {
-	EC_KEY *ecKey;
-
 	NSArray *blockedLicenseKeyHashes; // List of SHA-1 hashes of blocked license keys (without dashes). Use hashStringOfLicenseKey to get proper hash. Use setBlockedLicenseKeyHashes to set it.
 
 	unsigned int numberOfDashGroupCharacters; // number of characters in groups in final license key (xxxxx-xxxxx-...)

--- a/Framework/EllipticLicense.m
+++ b/Framework/EllipticLicense.m
@@ -18,6 +18,11 @@
 
 #import "EllipticLicense.h"
 #import "NSData+ELAdditions.h"
+#include <openssl/sha.h>
+#include <openssl/ec.h>
+#include <openssl/ecdsa.h>
+#include <openssl/obj_mac.h>
+#include <openssl/ossl_typ.h>
 
 #ifdef __clang__
 // OpenSSL is deprecated in OS X, but still good enough for licensing checks:
@@ -32,6 +37,10 @@
 NSString *ELCurveNameSecp112r1 = @"secp112r1";
 NSString *ELCurveNameSecp128r1 = @"secp128r1";
 NSString *ELCurveNameSecp160r1 = @"secp160r1";
+
+@interface EllipticLicense() {
+    EC_KEY *ecKey;
+}
 
 @interface EllipticLicense (Private)
 - (NSString *)stringSeparatedWithDashes:(NSString *)string;


### PR DESCRIPTION
I tried to use the library with cocoapods in my swift project and faced with error `Include of non-modular header inside framework module`. This PR fixes the problem.