### PR TITLE
Add ssl pod dependency to be able to compile on 10.11+

### DIFF
--- a/EllipticLicense.podspec
+++ b/EllipticLicense.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
 s.name         = "EllipticLicense"
-s.version      = "0.1.0"
+s.version      = "0.2.0"
 s.summary      = "Short product key generation and validation framework based on elliptic curves digital signatures (ECDSA). for Mac OS X/Cocoa."
 
 s.homepage     = "https://github.com/vslavik/ellipticlicense"
@@ -11,7 +11,7 @@ s.author       = { "Václav Slavík" => "vaclav@slavik.io" }
 
 s.platform     = :osx, "10.7"
 s.osx.deployment_target = "10.7"
-s.source       = { :git => "https://github.com/vslavik/ellipticlicense.git", :tag => "v0.1.0" }
+s.source       = { :git => "https://github.com/vslavik/ellipticlicense.git", :tag => "v0.2.0" }
 
 s.source_files = "Framework/*.{h,m}", "c_api/*.{h,c}"
 

--- a/EllipticLicense.podspec
+++ b/EllipticLicense.podspec
@@ -17,8 +17,9 @@ s.source_files = "Framework/*.{h,m}", "c_api/*.{h,c}"
 
 s.frameworks   = "Cocoa"
 
-s.library      = "crypto.0.9.8"
 s.requires_arc = true
 s.xcconfig     = { 'OTHER_LDFLAGS' => '-lObjC'}
+
+s.dependency  'OpenSSL-OSX'
 
 end


### PR DESCRIPTION
Couldn't create an issue, so creating a pull-request.
This dependency works for me on 10.11+, can't verify on `pod spec lint`, since it needs 0.2.0 tag on remote, but when specifying in `Podfile` it works well.
